### PR TITLE
Provide correct backtraces for loaded trees

### DIFF
--- a/examples/broken-people.rb
+++ b/examples/broken-people.rb
@@ -1,0 +1,6 @@
+person 'John S', 50
+person 'Andrea', 46
+person 'John R', 26
+raise "the roof"
+person 'Sarah', 24
+person 'Ethan', 10

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -33,7 +33,7 @@ class Lumberjack
 
   def load_tree_file(filename)
     File.open filename, 'r' do |f|
-      eval f.read, binding, __FILE__, __LINE__
+      eval f.read, binding, filename
     end
   end
 

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -227,6 +227,23 @@ describe Lumberjack do
     family.first.members.last.age.must_equal 10
   end
 
+  it 'provides accurate backtrace information when loading in files' do
+    begin
+      Lumberjack.construct do
+        family 'Barton' do
+          heritage [:dutch, :mongrel_aussie]
+          members do
+            load_tree_file 'examples/broken-people.rb'
+          end
+        end
+      end
+      raise "the dead"
+    rescue
+      $!.message.must_equal "the roof"
+      $!.backtrace.first.must_equal %{examples/broken-people.rb:4:in `block in load_tree_file'}
+    end
+  end
+
   it 'we can share branches that are defined' do
     families = Lumberjack.construct do
 


### PR DESCRIPTION
Loaded a tree file doesn't set the filename or line number so backtraces say obscure things like:

    .../gems/lumberjack-dsl-0.0.1/lumberjack.rb:912: warning: duplicated key at line 912 ignored: "foobar"

This will change it to output things like:

    my/loaded/file.rb:912: warning: duplicated key at line 912 ignored: "foobar"