### PR TITLE
Proposal: Use bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
+require "bundler/setup"
 require "bundler/gem_tasks"
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:spec) do |t|
   t.pattern = "spec/*_spec.rb"

--- a/lumberjack.gemspec
+++ b/lumberjack.gemspec
@@ -18,4 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.required_ruby_version     = '>= 1.9.3'
+
+  s.add_development_dependency "rake"
+  s.add_development_dependency "minitest"
 end

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -1,4 +1,3 @@
-$: << '.'
 require 'lumberjack'
 require 'minitest/autorun'
 


### PR DESCRIPTION
This makes the spec load the gem _as a gem_ and should highlight problems like the previous require_path inconsistencies.
