### PR TITLE
Update for Ruby 2.5

### DIFF
--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -38,7 +38,7 @@ class Lumberjack
   end
 
   def shared_branch(branch_name, &block)
-    instance_variable_set "@#{branch_name}", lambda(&block)
+    instance_variable_set "@#{branch_name}", block
   end
 
   def graft_branch(branch_name)


### PR DESCRIPTION
The `shared_branch` specs fail on Ruby 2.5. I think this is due to [Ruby 2.5's lazy procs](https://blog.bigbinary.com/2018/05/22/ruby-2-5-added-lazy-proc-allocation-for-block-parameters.html). In earlier Rubies, the block was already a `Proc` and the `lambda` call did not change it. But in Ruby 2.5 the block is converted to a `lambda`, and later `instance_eval` fails for mismatched arguments:

```
Lumberjack#test_0016_we can share branches that are defined:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /home/travis/build/boone/lumberjack/spec/lumberjack_spec.rb:249:in `block (4 levels) in <top (required)>'
    /home/travis/build/boone/lumberjack/lib/lumberjack.rb:47:in `instance_eval'
```

I don't think the `lambda` call is necessary here; without it the instance variable should be saved as a `Proc` regardless of Ruby version.

In a different branch on my fork, I added Travis CI and you can see the build results for the [original code](https://travis-ci.com/boone/lumberjack/builds/88865734) and with the [suggested fix](https://travis-ci.com/boone/lumberjack/builds/88865939).